### PR TITLE
Remove debug print from chart view

### DIFF
--- a/DjangoD3ChartApp/core/views.py
+++ b/DjangoD3ChartApp/core/views.py
@@ -95,7 +95,7 @@ def chart_view(request):
         for entry in september_data
     ]
     
-    print(chart_data)
+    # print(chart_data)
 
     context = {
         "chart_data": chart_data  # Pass the data as JSON-compatible dictionary


### PR DESCRIPTION
## Summary
- comment out debug `print(chart_data)` in `chart_view`

## Testing
- `python3 manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*
- `pip install -r ../requirements.txt` *(fails: Could not find a version that satisfies the requirement argon2-cffi==23.1.0)*

------
https://chatgpt.com/codex/tasks/task_e_689d7710f97c832d95351a444131b8a0